### PR TITLE
feat: add Docker build workflow

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,27 @@
+name: Docker Build
+
+on:
+  push:
+    branches: [main]
+    tags: ['v*']
+  pull_request:
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  docker:
+    uses: bjoernbethge/workflows-shared/.github/workflows/docker-build-push.yml@main
+    with:
+      dockerfile: Dockerfile
+      platforms: linux/amd64  # CUDA only supports amd64
+      push-dockerhub: ${{ github.event_name != 'pull_request' }}
+      dockerhub-username: bjoernbethge
+    secrets:
+      DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}


### PR DESCRIPTION
Adds automated Docker image builds using shared workflow:
- Builds for CUDA applications (linux/amd64 only)
- Pushes to GHCR (ghcr.io) and Docker Hub
- Smart tagging: latest, semver, SHA, branch names
- Automated on push to main, tags, and PRs

Requires DOCKERHUB_TOKEN secret to be configured.